### PR TITLE
Add hyperlink to xgov Slack

### DIFF
--- a/index.md
+++ b/index.md
@@ -17,4 +17,4 @@ To contribute, please raise an issue or a pull request on the Github repository:
 https://github.com/XGovFormBuilder/x-gov-form-community
 
 
-If you're interested in joining the community and find out more about the community, please email x-gov-forms@digital.cabinet-office.gov.uk or visit the #form-builders channel in the Cross-government Slack.
+If you're interested in joining the community and find out more about the community, please email x-gov-forms@digital.cabinet-office.gov.uk or visit the #form-builders channel in the [Cross-government Slack](https://ukgovernmentdigital.slack.com/).


### PR DESCRIPTION
Fix cross gov slack link