### PR TITLE
Update MoJ Forms links in Tools

### DIFF
--- a/tools.md
+++ b/tools.md
@@ -8,7 +8,7 @@ nav_order: 4
 ### Cross Government Form Tools
 
 - [XGov Digital Form Builder](https://github.com/XGovFormBuilder/digital-form-builder)
-- [MOJ Form Builder](https://github.com/ministryofjustice/form-builder) and [MOJ Forms product page](https://formbuilder-product-page.apps.live-1.cloud-platform.service.justice.gov.uk/)
+- [MOJ Forms product page](https://formbuilder-product-page.apps.live-1.cloud-platform.service.justice.gov.uk/) and [Legacy MOJ Form Builder](https://github.com/ministryofjustice/form-builder)
 - [GOV.UK Frontend WTForms, by HM Land Registry](https://govuk-frontend-wtf.herokuapp.com/)
 - [GOV.UK Design System Form Builder for Rails, by DfE Digital](https://github.com/DFE-Digital/govuk_design_system_formbuilder)
 - [DWP CASA](https://github.com/dwp/govuk-casa)


### PR DESCRIPTION
This is just to reiterate that the Form Builder product is now considered a Legacy tool